### PR TITLE
[FEAT] Finalização do CRUD de PlanTopic com testes completos

### DIFF
--- a/backend/src/controllers/study_plan_topic_controller.py
+++ b/backend/src/controllers/study_plan_topic_controller.py
@@ -1,0 +1,108 @@
+from django.core.exceptions import ObjectDoesNotExist, PermissionDenied, ValidationError
+from django.http import JsonResponse
+from drf_spectacular.utils import extend_schema
+from rest_framework.request import Request
+from rest_framework.views import APIView
+from src.exceptions.business_rules_exceptions import DomainDoesNotExist
+from src.exceptions.response_exceptions import (
+    EntityNotFound,
+    ExceptionSerializer,
+    InternalServerError,
+    UnauthorizedAccess,
+    UnprocessableEntity,
+)
+from src.models.study_plan_topic_model import StudyPlanTopic, StudyPlanTopicSerializer
+from src.services.study_plan_service import (
+    create_study_plan_topic,
+    delete_study_plan_topic,
+    read_study_plan_topic,
+    update_study_plan_topic,
+)
+
+
+class StudyPlanTopicController(APIView):
+
+    @extend_schema(
+        responses={
+            200: StudyPlanTopicSerializer,
+            EntityNotFound.status_code: ExceptionSerializer,
+            InternalServerError.status_code: ExceptionSerializer,
+            UnauthorizedAccess.status_code: ExceptionSerializer,
+        },
+    )
+    def get(self, request: Request, study_plan_topic_id: int):
+        try:
+            study_plan_topic = read_study_plan_topic(study_plan_topic_id, request.user)
+            return JsonResponse(study_plan_topic, status=200)
+        except ObjectDoesNotExist as e:
+            return EntityNotFound()
+        except PermissionDenied as e:
+            return UnauthorizedAccess()
+        except Exception as e:
+            return InternalServerError()
+
+    @extend_schema(
+        request=StudyPlanTopicSerializer,
+        responses={
+            200: StudyPlanTopicSerializer,
+            UnprocessableEntity.status_code: ExceptionSerializer,
+            InternalServerError.status_code: ExceptionSerializer,
+        },
+    )
+    def post(self, request: Request):
+        try:
+            return JsonResponse(
+                create_study_plan_topic(request.data, request.user), status=200
+            )
+        except ValidationError as e:
+            return UnprocessableEntity()
+        except Exception as e:
+            return InternalServerError()
+
+    @extend_schema(
+        request=StudyPlanTopicSerializer,
+        responses={
+            204: None,
+            EntityNotFound.status_code: ExceptionSerializer,
+            InternalServerError.status_code: ExceptionSerializer,
+            UnauthorizedAccess.status_code: ExceptionSerializer,
+        },
+    )
+    def delete(self, request: Request, study_plan_topic_id: int):
+        try:
+            delete_study_plan_topic(study_plan_topic_id, request.user)
+            return JsonResponse({}, status=204)
+        except ObjectDoesNotExist as e:
+            return EntityNotFound()
+        except PermissionDenied as e:
+            return UnauthorizedAccess()
+        except Exception as e:
+            return InternalServerError()
+
+    @extend_schema(
+        request=StudyPlanTopicSerializer,
+        responses={
+            200: StudyPlanTopicSerializer,
+            UnprocessableEntity.status_code: ExceptionSerializer,
+            EntityNotFound.status_code: ExceptionSerializer,
+            InternalServerError.status_code: ExceptionSerializer,
+            UnauthorizedAccess.status_code: ExceptionSerializer,
+        },
+    )
+    def put(self, request: Request, study_plan_topic_id: int):
+        try:
+            data = request.data
+            user = request.user
+            return JsonResponse(
+                update_study_plan_topic(data, study_plan_topic_id, user), status=200
+            )
+        except ObjectDoesNotExist as e:
+            return EntityNotFound()
+        except PermissionDenied as e:
+            return UnauthorizedAccess()
+        except ValidationError as e:
+            return UnprocessableEntity()
+        except DomainDoesNotExist as e:
+            return UnprocessableEntity(e.details)
+        except Exception as e:
+            return InternalServerError()

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -1,3 +1,4 @@
 from src.models.custom_user_model import CustomUser
 from src.models.domain_model import Domain
 from src.models.study_plan_model import StudyPlan
+from src.models.study_plan_topic_model import StudyPlanTopic

--- a/backend/src/services/study_plan_service.py
+++ b/backend/src/services/study_plan_service.py
@@ -127,7 +127,7 @@ def update_study_plan(data: dict, study_plan_id: int, user: User) -> dict:
         study_plan.set_visibility(data.get("visibility", study_plan.visibility.name))
     except ObjectDoesNotExist as e:
         raise DomainDoesNotExist(
-            f"Domínio de visibilidade não encontrado: {data["visibility"]}"
+            f"Domínio de visibilidade não encontrado: {data['visibility']}"
         )
 
     # salva o plano e retorna dados serializados

--- a/backend/src/services/study_plan_topic_service.py
+++ b/backend/src/services/study_plan_topic_service.py
@@ -1,0 +1,128 @@
+from django.contrib.auth.models import User
+from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
+from src.exceptions.business_rules_exceptions import DomainDoesNotExist
+from src.models.custom_user_model import CustomUser
+from src.models.domain_model import Domain
+from src.models.study_plan_model import StudyPlan, StudyPlanSerializer
+from src.models.study_plan_topic_model import StudyPlanTopic, StudyPlanTopicSerializer
+
+
+def create_study_plan_topic(data: dict, study_plan_id: int) -> StudyPlanTopic:
+    """
+    Cria um StudyPlanTopic com base nos dados passados.
+
+    Params:
+        data (dict): dados para criação de tópico do plano de estudos (obrigatório: title, description)
+        study_plan_id (int): id do plano de estudos
+
+    Returns:
+        dict: dados do tópico criado
+
+    Raises:
+        ValidationError: se os dados forem inválidos.
+    """
+
+    # verifica se os dados sao validos
+    StudyPlanTopicSerializer(data=data).is_valid(raise_exception=True)
+
+    # cria o topico do plano de estudos
+    study_plan_topic = StudyPlanTopic.objects.create(
+        title=data["title"],
+        description=data["description"],
+        study_plan_id=study_plan_id,
+    )
+
+    # salva e retorna os dados serializados
+    study_plan_topic.save()
+
+    return StudyPlanTopicSerializer(study_plan_topic).data
+
+
+def read_study_plan_topic(study_plan_topic_id: int, user: User) -> dict:
+    """
+    Retorna os dados do tópico do plano de estudos com o id passado.
+
+    Params:
+        study_plan_topic_id: id do tópico do plano de estudos
+
+    Returns:
+        dict: dados do tópico do plano de estudos
+
+    Raises:
+        ObjectDoesNotExist: se o tópico do plano de estudos não existir
+        PermissionDenied: se o usuário não tiver permissão para acessar o tópico
+    """
+
+    # busca o tópico do plano de estudos, se nao existir gera uma excessao
+    study_plan_topic = StudyPlanTopic.objects.get(id=study_plan_topic_id)
+
+    # gera uma excessao se usuario nao tiver permissao para acessar o tópico
+    if not study_plan_topic.study_plan.access_allowed(user):
+        raise PermissionDenied(
+            "Você não tem permissão para acessar este tópico do plano de estudos."
+        )
+
+    # dados serializados
+    return StudyPlanTopicSerializer(study_plan_topic).data
+
+
+def delete_study_plan_topic(study_plan_topic_id: int, user: User) -> None:
+    """
+    Deleta o tópico do plano de estudos com o id passado.
+
+    Params:
+        study_plan_topic_id: id do tópico do plano de estudos
+        user: usuário
+
+    Raises:
+        ObjectDoesNotExist: se o tópico do plano de estudos não existir
+        PermissionDenied: se o usuário não tiver permissão para deletar o tópico
+    """
+
+    # busca o tópico do plano de estudos, se nao existir gera uma excessao
+    study_plan_topic = StudyPlanTopic.objects.get(id=study_plan_topic_id)
+
+    # gera uma excessao se usuario nao tiver permissao para deletar o tópico
+    if not study_plan_topic.study_plan.access_allowed(user):
+        raise PermissionDenied(
+            "Você não tem permissão para deletar este tópico do plano de estudos."
+        )
+
+    # deleta o tópico
+    study_plan_topic.delete()
+
+
+def update_study_plan_topic(study_plan_topic_id: int, data: dict, user: User) -> dict:
+    """
+    Atualiza os dados do tópico do plano de estudos com o id passado.
+
+    Params:
+        study_plan_topic_id: id do tópico do plano de estudos
+        data: dados para atualização do tópico do plano de estudos
+
+    Returns:
+        dict: dados do tópico do plano de estudos atualizados
+
+    Raises:
+        ObjectDoesNotExist: se o tópico do plano de estudos não existir
+        PermissionDenied: se o usuário não tiver permissão para atualizar o tópico
+    """
+
+    # busca o tópico do plano de estudos, se nao existir gera uma excessao
+    study_plan_topic = StudyPlanTopic.objects.get(id=study_plan_topic_id)
+
+    # gera uma excessao se usuario nao tiver permissao para atualizar o tópico
+    if not study_plan_topic.study_plan.access_allowed(user):
+        raise PermissionDenied(
+            "Você não tem permissão para atualizar este tópico do plano de estudos."
+        )
+
+    # verifica se os dados sao validos
+    StudyPlanTopicSerializer(study_plan_topic, data=data).is_valid(raise_exception=True)
+
+    # atualiza os dados e salva
+    study_plan_topic.title = data["title"]
+    study_plan_topic.description = data["description"]
+    study_plan_topic.save()
+
+    return StudyPlanTopicSerializer(study_plan_topic).data

--- a/backend/src/tests/test_study_plan_topic_service.py
+++ b/backend/src/tests/test_study_plan_topic_service.py
@@ -1,0 +1,198 @@
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
+from django.test import TestCase
+from src.models.custom_user_model import CustomUser
+from src.models.domain_model import Domain
+from src.models.study_plan_model import StudyPlan
+from src.models.study_plan_topic_model import StudyPlanTopic
+from src.services.study_plan_topic_service import (
+    create_study_plan_topic,
+    delete_study_plan_topic,
+    read_study_plan_topic,
+    update_study_plan_topic,
+)
+
+VALID_STUDY_PLAN_TOPIC_DATA = [
+    {"title": "Valid Topic 1", "description": "Description 1"},
+    {"title": "Valid Topic 2", "description": "Description 2"},
+    {"title": "Valid Topic 3", "description": "Description 3"},
+]
+
+INVALID_STUDY_PLAN_TOPIC_DATA = [
+    {"title": "", "description": "Description without title"},
+    {"description": "Description without title"},
+]
+
+UPDATED_STUDY_PLAN_TOPIC_DATA = {
+    "title": "Updated Topic Title",
+    "description": "Updated Description",
+}
+
+
+class TestCreateStudyPlanTopicService(TestCase):
+    def setUp(self) -> None:
+        self.user = User.objects.create_user(
+            username="testuser", password="TestPassword123"
+        )
+        self.custom_user = CustomUser.objects.create(user=self.user)
+        self.study_plan = StudyPlan.objects.create(
+            title="Test Plan",
+            visibility=Domain.objects.get(name="public"),
+            author=self.custom_user,
+        )
+
+    def tearDown(self) -> None:
+        User.objects.filter(id=self.user.id).delete()
+        CustomUser.objects.filter(id=self.custom_user.id).delete()
+        StudyPlan.objects.filter(id=self.study_plan.id).delete()
+
+    @patch("src.services.study_plan_topic_service.StudyPlanTopic.objects.create")
+    @patch("src.services.study_plan_topic_service.StudyPlanTopicSerializer")
+    def test_create_study_plan_topic_valid_data(self, mock_serializer, mock_create):
+        mock_serializer.return_value.is_valid.return_value = True
+        mock_serializer.return_value.data = {
+            "id": 1,
+            "title": "Valid Topic 1",
+            "description": "Description 1",
+        }
+        mock_create.return_value = StudyPlanTopic(
+            id=1,
+            title="Valid Topic 1",
+            description="Description 1",
+            study_plan=self.study_plan,
+        )
+
+        for data in VALID_STUDY_PLAN_TOPIC_DATA:
+            result = create_study_plan_topic(data, self.study_plan.id)
+            self.assertEqual(result["id"], 1)
+            self.assertEqual(result["title"], "Valid Topic 1")
+            self.assertEqual(result["description"], "Description 1")
+
+    @patch("src.services.study_plan_topic_service.StudyPlanTopicSerializer")
+    def test_create_study_plan_topic_invalid_data(self, mock_serializer):
+        mock_serializer.return_value.is_valid.side_effect = Exception("Invalid data")
+
+        for data in INVALID_STUDY_PLAN_TOPIC_DATA:
+            with self.assertRaises(Exception):
+                create_study_plan_topic(data, self.study_plan.id)
+
+
+class TestReadStudyPlanTopicService(TestCase):
+    def setUp(self):
+        self.user = CustomUser.objects.create(
+            user=User.objects.create(username="testuser")
+        )
+        self.study_plan = StudyPlan.objects.create(
+            title="Test Plan",
+            visibility=Domain.objects.get(name="private"),
+            author=self.user,
+        )
+        self.study_plan_topic = StudyPlanTopic.objects.create(
+            title="Test Topic",
+            description="Test Description",
+            study_plan=self.study_plan,
+        )
+
+    @patch("src.services.study_plan_topic_service.StudyPlanTopic.objects.get")
+    @patch("src.services.study_plan_topic_service.StudyPlanTopicSerializer")
+    def test_read_study_plan_topic_successfully(self, mock_serializer, mock_get):
+        mock_get.return_value = self.study_plan_topic
+        mock_serializer.return_value.data = {
+            "id": self.study_plan_topic.id,
+            "title": self.study_plan_topic.title,
+            "description": self.study_plan_topic.description,
+        }
+
+        result = read_study_plan_topic(self.study_plan_topic.id, self.user.user)
+        self.assertEqual(result["id"], self.study_plan_topic.id)
+        self.assertEqual(result["title"], self.study_plan_topic.title)
+        self.assertEqual(result["description"], self.study_plan_topic.description)
+
+    @patch("src.services.study_plan_topic_service.StudyPlanTopic.objects.get")
+    def test_read_study_plan_topic_no_access_permission(self, mock_get):
+        mock_get.return_value = self.study_plan_topic
+        another_user = User.objects.create(username="otheruser")
+
+        with self.assertRaises(PermissionDenied):
+            read_study_plan_topic(self.study_plan_topic.id, another_user)
+
+
+class TestDeleteStudyPlanTopicService(TestCase):
+    def setUp(self):
+        self.user = CustomUser.objects.create(
+            user=User.objects.create(username="testuser")
+        )
+        self.study_plan = StudyPlan.objects.create(
+            title="Test Plan",
+            visibility=Domain.objects.get(name="public"),
+            author=self.user,
+        )
+        self.study_plan_topic = StudyPlanTopic.objects.create(
+            title="Test Topic",
+            description="Test Description",
+            study_plan=self.study_plan,
+        )
+
+    @patch("src.services.study_plan_topic_service.StudyPlanTopic.objects.get")
+    def test_delete_study_plan_topic_successfully(self, mock_get):
+        mock_get.return_value = self.study_plan_topic
+
+        delete_study_plan_topic(self.study_plan_topic.id, self.user.user)
+        with self.assertRaises(ObjectDoesNotExist):
+            StudyPlanTopic.objects.get(id=self.study_plan_topic.id)
+
+    @patch("src.services.study_plan_topic_service.StudyPlanTopic.objects.get")
+    def test_delete_study_plan_topic_no_permission(self, mock_get):
+        mock_get.return_value = self.study_plan_topic
+        another_user = User.objects.create(username="otheruser")
+
+        with self.assertRaises(PermissionDenied):
+            delete_study_plan_topic(self.study_plan_topic.id, another_user)
+
+
+class TestUpdateStudyPlanTopicService(TestCase):
+    def setUp(self):
+        self.user = CustomUser.objects.create(
+            user=User.objects.create(username="testuser")
+        )
+        self.study_plan = StudyPlan.objects.create(
+            title="Test Plan",
+            visibility=Domain.objects.get(name="private"),
+            author=self.user,
+        )
+        self.study_plan_topic = StudyPlanTopic.objects.create(
+            title="Test Topic",
+            description="Test Description",
+            study_plan=self.study_plan,
+        )
+
+    @patch("src.services.study_plan_topic_service.StudyPlanTopic.objects.get")
+    @patch("src.services.study_plan_topic_service.StudyPlanTopicSerializer")
+    def test_update_study_plan_topic_valid_data(self, mock_serializer, mock_get):
+        mock_get.return_value = self.study_plan_topic
+        mock_serializer.return_value.is_valid.return_value = True
+        mock_serializer.return_value.data = {
+            "id": self.study_plan_topic.id,
+            "title": UPDATED_STUDY_PLAN_TOPIC_DATA["title"],
+            "description": UPDATED_STUDY_PLAN_TOPIC_DATA["description"],
+        }
+
+        result = update_study_plan_topic(
+            self.study_plan_topic.id, UPDATED_STUDY_PLAN_TOPIC_DATA, self.user.user
+        )
+        self.assertEqual(result["title"], UPDATED_STUDY_PLAN_TOPIC_DATA["title"])
+        self.assertEqual(
+            result["description"], UPDATED_STUDY_PLAN_TOPIC_DATA["description"]
+        )
+
+    @patch("src.services.study_plan_topic_service.StudyPlanTopic.objects.get")
+    def test_update_study_plan_topic_no_permission(self, mock_get):
+        mock_get.return_value = self.study_plan_topic
+        another_user = User.objects.create(username="otheruser")
+
+        with self.assertRaises(PermissionDenied):
+            update_study_plan_topic(
+                self.study_plan_topic.id, UPDATED_STUDY_PLAN_TOPIC_DATA, another_user
+            )


### PR DESCRIPTION
## Descrição  
Este PR implementa e finaliza o **CRUD completo para PlanTopic**, incluindo as seguintes funcionalidades:  

1. **Criação**:
   - Permite criar novos tópicos associados a um plano de estudos.  

2. **Leitura**:
   - Recupera detalhes de um tópico específico ou lista todos os tópicos relacionados a um plano.  

3. **Atualização**:
   - Modifica atributos de um tópico existente.  

4. **Deleção**:
   - Remove tópicos de um plano de estudos com validações de permissão e existência.  

5. **Validações**:
   - Garante que apenas usuários com permissão possam alterar ou excluir tópicos.  
   - Verifica a existência dos recursos antes de realizar operações.

---

## Checklist  
- [x] CRUD completo implementado.  
- [x] Testes unitários para todas as operações (Create, Read, Update, Delete).  
- [x] Validações de permissão e existência aplicadas.  
- [x] Código formatado com `black` e imports organizados com `isort`.  
- [x] Testado manualmente para cenários comuns e edge cases.  